### PR TITLE
fix(security): add contact methods to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,8 @@ Security issues may affect any repository in the `baena-labs` organization.
 
 Do not open public issues for suspected vulnerabilities.
 
-Report security concerns privately using one of:
-
-1. **GitHub Security Advisories** — open a private advisory on the affected repository via _Security → Report a vulnerability_.
-2. **Email** — send details to **security@baena-labs.dev**.
+Report security concerns privately via **GitHub Security Advisories** — open a
+private advisory on the affected repository under _Security → Report a vulnerability_.
 
 Include the following in your report:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,12 @@ Security issues may affect any repository in the `baena-labs` organization.
 
 Do not open public issues for suspected vulnerabilities.
 
-Report security concerns privately to the organization maintainers with:
+Report security concerns privately using one of:
+
+1. **GitHub Security Advisories** — open a private advisory on the affected repository via _Security → Report a vulnerability_.
+2. **Email** — send details to **security@baena-labs.dev**.
+
+Include the following in your report:
 
 - affected repository
 - suspected impact


### PR DESCRIPTION
## Summary
- Adds two concrete reporting channels: GitHub Security Advisories and email (security@baena-labs.dev)
- Previously the policy said "report privately" with no way to actually do so

Closes #6

## Test plan
- [ ] Verify SECURITY.md renders correctly on GitHub
- [ ] Confirm email address is correct (update if using a different domain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)