### PR TITLE
feat(docs): add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+Thanks for contributing to `baena-labs`. These guidelines apply across all
+repositories in the organization unless a repo provides its own.
+
+## Workflow
+
+1. Open an issue or feature request before starting non-trivial work.
+2. Create a feature branch from the default branch.
+3. Keep pull requests small and focused — one concern per PR.
+4. Fill out the PR template (Context, Description, Validation, Risks).
+5. All PRs require at least one review before merge.
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short summary>
+```
+
+Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`.
+
+## Code standards
+
+- Follow existing patterns in the repository before introducing new ones.
+- Do not add dependencies without justification.
+- Add or update tests when behavior changes.
+- Do not weaken security controls, workflow permissions, or branch protections.
+
+## Security
+
+Do **not** open public issues for security vulnerabilities.
+See [SECURITY.md](SECURITY.md) for responsible disclosure instructions.
+
+## Questions
+
+Open a discussion or issue — we're happy to help.


### PR DESCRIPTION
## Summary
- Adds org-wide contributing guide covering PR workflow, conventional commits, code standards, and security reporting
- GitHub surfaces this as a community health file across all repos without their own

Closes #7

## Test plan
- [ ] Verify GitHub shows it in the community health section
- [ ] Confirm SECURITY.md link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)