### PR TITLE
feat(docs): add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to providing a welcoming and respectful environment for
+everyone, regardless of experience level, background, identity, or perspective.
+
+## Expected Behavior
+
+- Be respectful and constructive in discussions, code reviews, and issues.
+- Assume good intent and ask clarifying questions before reacting.
+- Give and accept feedback gracefully.
+- Focus on what is best for the project and team.
+
+## Unacceptable Behavior
+
+- Harassment, insults, or personal attacks.
+- Publishing others' private information without permission.
+- Sustained disruption of discussions or workflows.
+- Any conduct that would be considered inappropriate in a professional setting.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported privately to the organization
+maintainers. All reports will be reviewed and handled with discretion.
+
+Maintainers may take any action they deem appropriate, including warnings,
+temporary bans, or permanent removal from the organization.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,8 +21,9 @@ everyone, regardless of experience level, background, identity, or perspective.
 
 ## Enforcement
 
-Instances of unacceptable behavior may be reported privately to the organization
-maintainers. All reports will be reviewed and handled with discretion.
+Instances of unacceptable behavior may be reported privately by emailing
+[conduct@baena-labs.dev](mailto:conduct@baena-labs.dev). All reports will be
+reviewed and handled with discretion.
 
 Maintainers may take any action they deem appropriate, including warnings,
 temporary bans, or permanent removal from the organization.


### PR DESCRIPTION
## Summary
- Adds a concise code of conduct adapted from Contributor Covenant v2.1
- Completes another GitHub community health file for the org

Closes #8

## Test plan
- [ ] Verify GitHub shows it in the community health section

🤖 Generated with [Claude Code](https://claude.com/claude-code)