### PR TITLE
feat(ci): add reusable lint, test, and security workflows

### DIFF
--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -1,0 +1,33 @@
+name: Reusable — Lint
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: "Node.js version for linting"
+        required: false
+        type: string
+        default: "20"
+      lint-command:
+        description: "Lint command to run"
+        required: false
+        type: string
+        default: "npm run lint"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+
+      - run: npm ci
+
+      - run: ${{ inputs.lint-command }}

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: "npm run lint"
+      install-command:
+        description: "Install command to run before linting (assumes npm + package-lock.json by default)"
+        required: false
+        type: string
+        default: "npm ci"
 
 permissions:
   contents: read
@@ -20,6 +25,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -28,6 +34,6 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: npm
 
-      - run: npm ci
+      - run: ${{ inputs.install-command }}
 
       - run: ${{ inputs.lint-command }}

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   codeql:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -29,6 +30,7 @@ jobs:
 
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -1,0 +1,36 @@
+name: Reusable — Security scan
+
+on:
+  workflow_call:
+    inputs:
+      language:
+        description: "CodeQL language (javascript, python, go, etc.)"
+        required: false
+        type: string
+        default: "javascript"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ inputs.language }}
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+
+  dependency-review:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/dependency-review-action@v4

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -1,0 +1,33 @@
+name: Reusable — Test
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: "Node.js version for tests"
+        required: false
+        type: string
+        default: "20"
+      test-command:
+        description: "Test command to run"
+        required: false
+        type: string
+        default: "npm test"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+
+      - run: npm ci
+
+      - run: ${{ inputs.test-command }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: "npm test"
+      install-command:
+        description: "Install command to run before tests (assumes npm + package-lock.json by default)"
+        required: false
+        type: string
+        default: "npm ci"
 
 permissions:
   contents: read
@@ -20,6 +25,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -28,6 +34,6 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: npm
 
-      - run: npm ci
+      - run: ${{ inputs.install-command }}
 
       - run: ${{ inputs.test-command }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,32 @@ surface across repositories, plus shared templates and policy documents.
 - pull request templates
 - reusable workflows when they are stable enough to share
 
+## Reusable workflows
+
+Shared GitHub Actions workflows that any `baena-labs` repo can call.
+
+| Workflow | File | Inputs | Permissions |
+|----------|------|--------|-------------|
+| Lint | `reusable-lint.yml` | `node-version` (default `20`), `lint-command` (default `npm run lint`) | `contents: read` |
+| Test | `reusable-test.yml` | `node-version` (default `20`), `test-command` (default `npm test`) | `contents: read` |
+| Security | `reusable-security.yml` | `language` (default `javascript`) | `contents: read`, `security-events: write` |
+
+### Usage
+
+```yaml
+jobs:
+  lint:
+    uses: baena-labs/.github/.github/workflows/reusable-lint.yml@main
+    with:
+      node-version: "20"
+```
+
+### Security assumptions
+
+- Workflows run with minimal permissions; callers must not escalate.
+- Security scan writes to GitHub Security tab via `security-events: write`.
+- Dependency review only runs on pull requests.
+
 ## What does not belong here
 
 - organization rulesets

--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@ Shared GitHub Actions workflows that any `baena-labs` repo can call.
 
 | Workflow | File | Inputs | Permissions |
 |----------|------|--------|-------------|
-| Lint | `reusable-lint.yml` | `node-version` (default `20`), `lint-command` (default `npm run lint`) | `contents: read` |
-| Test | `reusable-test.yml` | `node-version` (default `20`), `test-command` (default `npm test`) | `contents: read` |
+| Lint | `reusable-lint.yml` | `node-version` (default `20`), `lint-command` (default `npm run lint`), `install-command` (default `npm ci`) | `contents: read` |
+| Test | `reusable-test.yml` | `node-version` (default `20`), `test-command` (default `npm test`), `install-command` (default `npm ci`) | `contents: read` |
 | Security | `reusable-security.yml` | `language` (default `javascript`) | `contents: read`, `security-events: write` |
+
+### Caller requirements
+
+- **`reusable-lint.yml` and `reusable-test.yml`** are Node-based and assume an npm project with a `package-lock.json` (used for `cache: npm` and the default `npm ci`). For yarn/pnpm, override `install-command` — note that the dependency cache will still be configured for npm. Non-Node repos should use their own workflow.
+- **`reusable-security.yml`** uses CodeQL. For TypeScript-heavy repos, pass `language: javascript-typescript` (the modern identifier covers both JS and TS).
 
 ### Usage
 
@@ -38,6 +43,7 @@ jobs:
 - Workflows run with minimal permissions; callers must not escalate.
 - Security scan writes to GitHub Security tab via `security-events: write`.
 - Dependency review only runs on pull requests.
+- All jobs have `timeout-minutes` set to bound runner usage.
 
 ## What does not belong here
 


### PR DESCRIPTION
## Summary
- Adds three reusable GitHub Actions workflows: lint, test, and security scan (CodeQL + dependency review)
- All workflows use `workflow_call` with configurable inputs and minimal permissions
- Documents inputs, permissions, and security assumptions in `README.md` per `AGENTS.md` requirements

Closes #10

## Test plan
- [ ] Call `reusable-lint.yml` from a downstream repo and verify it runs
- [ ] Call `reusable-test.yml` from a downstream repo and verify it runs
- [ ] Call `reusable-security.yml` from a downstream repo and verify CodeQL + dependency review run
- [ ] Verify README renders the workflow table correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)