### PR TITLE
chore(ci): pin actions to commit SHAs + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -18,21 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
         with:
           languages: ${{ inputs.language }}
 
-      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/autobuild@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
 
   dependency-review:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ jobs:
 - Security scan writes to GitHub Security tab via `security-events: write`.
 - Dependency review only runs on pull requests.
 - All jobs have `timeout-minutes` set to bound runner usage.
+- All third-party actions are pinned to commit SHAs (with a trailing `# vX.Y.Z` comment) and bumped weekly via Dependabot — see `.github/dependabot.yml`.
 
 ## What does not belong here
 


### PR DESCRIPTION
## Summary
- Pin every third-party action in the reusable workflows to a commit SHA, with a trailing `# vX.Y.Z` comment for human readability. SHAs resolved from upstream repos' latest **v4.x / v3.x** release tags — this is purely a pin, no major-version bumps.
- Add `.github/dependabot.yml` to bump pins weekly, grouped into one rollup PR per week via the `actions` group.
- Document the new posture under "Security assumptions" in `README.md`.

Closes #18.

## SHAs pinned

| Action | Tag | SHA |
|---|---|---|
| `actions/checkout` | v4.3.1 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-node` | v4.4.0 | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `actions/dependency-review-action` | v4.9.0 | `2031cfc080254a8a887f58cffee85186f0e49e48` |
| `github/codeql-action` (init / autobuild / analyze) | v3.35.3 | `0daab03d71ff584ef619d027a3fd9146679c5d84` |

Each SHA was resolved live via `gh api repos/<owner>/<repo>/commits/<tag>` against the upstream repo — none of these are the SHAs Copilot suggested in #17 (those were not verified).

## Why

Mutable version tags can be re-pointed by a compromised maintainer. For org-wide reusable workflows that every downstream `baena-labs` repo eventually calls, that risk inherits everywhere. SHA-pinning is GitHub's recommended practice for shared workflows. Dependabot handles the bump cadence so pins don't silently rot.

## Test plan

- [ ] Confirm Dependabot picks up `.github/dependabot.yml` (Insights → Dependency graph → Dependabot, or just wait for the first scheduled run)
- [ ] Verify the reusable workflows still execute correctly when called from a downstream repo (existing call sites, if any)
- [ ] On next Dependabot bump, confirm the grouped PR rolls up multiple actions into one PR with the `chore(deps)` prefix

## Notes

- Major version upgrades (`@v4` → `@v6` for setup-node, etc.) are deliberately **out of scope** for this PR. Dependabot will not auto-bump majors by default; reviewing those is a separate decision.
- No `labels:` set on the Dependabot config (the repo only has the default GitHub label set today). Easy to add later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)