### PR TITLE
feat(ci): add reusable render-diagrams workflow

### DIFF
--- a/.github/workflows/reusable-render-diagrams.yml
+++ b/.github/workflows/reusable-render-diagrams.yml
@@ -61,9 +61,13 @@ jobs:
           mkdir -p "$OUTPUT_DIR"
           shopt -s nullglob
           rendered=0
+          # Run each script with cwd=OUTPUT_DIR so the `diagrams` library's
+          # default output (the current working directory) lands inside
+          # output-dir without each script needing to know its absolute path.
           for f in "$SOURCE_DIR"/*.py; do
             echo "Rendering $f"
-            python "$f"
+            abs_f="$(realpath "$f")"
+            ( cd "$OUTPUT_DIR" && python "$abs_f" )
             rendered=$((rendered + 1))
           done
           if [ "$rendered" -eq 0 ]; then
@@ -77,7 +81,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "$OUTPUT_DIR"/*.png 2>/dev/null || true
+          # Stage the directory (not just *.png) so deletions of removed
+          # diagrams are also captured — otherwise stale PNGs persist.
+          git add -A "$OUTPUT_DIR"
           if git diff --staged --quiet; then
             echo "No changes to rendered output — skipping commit."
           else

--- a/.github/workflows/reusable-render-diagrams.yml
+++ b/.github/workflows/reusable-render-diagrams.yml
@@ -1,0 +1,86 @@
+name: Reusable — Render diagrams
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version used to render diagrams"
+        required: false
+        type: string
+        default: "3.12"
+      diagrams-version:
+        description: "Pinned version of the `diagrams` PyPI package"
+        required: false
+        type: string
+        default: "0.25.1"
+      source-dir:
+        description: "Directory containing diagram source scripts (*.py)"
+        required: false
+        type: string
+        default: "diagrams"
+      output-dir:
+        description: "Directory where rendered PNGs are committed"
+        required: false
+        type: string
+        default: "docs/diagrams"
+      commit-message:
+        description: "Commit message used when rendered output changes"
+        required: false
+        type: string
+        default: "chore(diagrams): render architecture diagrams [skip ci]"
+
+permissions:
+  contents: read
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Install Graphviz
+        run: sudo apt-get update && sudo apt-get install -y graphviz
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install diagrams
+        run: pip install "diagrams==${{ inputs.diagrams-version }}"
+
+      - name: Render all diagrams
+        env:
+          SOURCE_DIR: ${{ inputs.source-dir }}
+          OUTPUT_DIR: ${{ inputs.output-dir }}
+        run: |
+          mkdir -p "$OUTPUT_DIR"
+          shopt -s nullglob
+          rendered=0
+          for f in "$SOURCE_DIR"/*.py; do
+            echo "Rendering $f"
+            python "$f"
+            rendered=$((rendered + 1))
+          done
+          if [ "$rendered" -eq 0 ]; then
+            echo "No *.py files found in $SOURCE_DIR — nothing to render."
+          fi
+
+      - name: Commit rendered output
+        env:
+          OUTPUT_DIR: ${{ inputs.output-dir }}
+          COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$OUTPUT_DIR"/*.png 2>/dev/null || true
+          if git diff --staged --quiet; then
+            echo "No changes to rendered output — skipping commit."
+          else
+            git commit -m "$COMMIT_MESSAGE"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Shared GitHub Actions workflows that any `baena-labs` repo can call.
 | Lint | `reusable-lint.yml` | `node-version` (default `20`), `lint-command` (default `npm run lint`), `install-command` (default `npm ci`) | `contents: read` |
 | Test | `reusable-test.yml` | `node-version` (default `20`), `test-command` (default `npm test`), `install-command` (default `npm ci`) | `contents: read` |
 | Security | `reusable-security.yml` | `language` (default `javascript`) | `contents: read`, `security-events: write` |
+| Render diagrams | `reusable-render-diagrams.yml` | `python-version` (default `3.12`), `diagrams-version` (default `0.25.1`), `source-dir` (default `diagrams`), `output-dir` (default `docs/diagrams`), `commit-message` | `contents: write` |
 
 ### Caller requirements
 
 - **`reusable-lint.yml` and `reusable-test.yml`** are Node-based and assume an npm project with a `package-lock.json` (used for `cache: npm` and the default `npm ci`). For yarn/pnpm, override `install-command` — note that the dependency cache will still be configured for npm. Non-Node repos should use their own workflow.
 - **`reusable-security.yml`** uses CodeQL. For TypeScript-heavy repos, pass `language: javascript-typescript` (the modern identifier covers both JS and TS).
+- **`reusable-render-diagrams.yml`** assumes diagrams are written with the [`diagrams`](https://diagrams.mingrammer.com/) Python library, one Python file per diagram, sourced from `source-dir`. The job pushes rendered PNGs back to the calling branch — callers must grant `permissions: contents: write` and should invoke this on `push` events (not `pull_request` from forks, where the push will fail). Branch-protected branches that require signed or reviewed commits will reject the bot push; in those cases call this on a separate branch and open a PR.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Shared GitHub Actions workflows that any `baena-labs` repo can call.
 | Lint | `reusable-lint.yml` | `node-version` (default `20`), `lint-command` (default `npm run lint`), `install-command` (default `npm ci`) | `contents: read` |
 | Test | `reusable-test.yml` | `node-version` (default `20`), `test-command` (default `npm test`), `install-command` (default `npm ci`) | `contents: read` |
 | Security | `reusable-security.yml` | `language` (default `javascript`) | `contents: read`, `security-events: write` |
-| Render diagrams | `reusable-render-diagrams.yml` | `python-version` (default `3.12`), `diagrams-version` (default `0.25.1`), `source-dir` (default `diagrams`), `output-dir` (default `docs/diagrams`), `commit-message` | `contents: write` |
+| Render diagrams | `reusable-render-diagrams.yml` | `python-version` (default `3.12`), `diagrams-version` (default `0.25.1`), `source-dir` (default `diagrams`), `output-dir` (default `docs/diagrams`), `commit-message` (default `chore(diagrams): render architecture diagrams [skip ci]`) | `contents: write` |
 
 ### Caller requirements
 


### PR DESCRIPTION
## Summary
- Ports `render-diagrams.yml` from `baena-labs/ai-template` (private) into this public repo as a `workflow_call` reusable workflow, following the pattern from #17.
- Generalizes hardcoded values (paths, versions, commit message) into inputs.
- SHA-pins both actions used (`actions/checkout` v4.3.1, `actions/setup-python` v5.6.0) so this lands consistent with #18's posture.

Closes part of #19. The other candidate (`validate-ai-layer.yml`) is deliberately **not** ported — see the [triage comment on #19](https://github.com/baena-labs/.github/issues/19#issuecomment-4365383739) for the reasoning (it leaks the private AI scaffolding's structure into a public repo).

## Changes from the source workflow

| Aspect | ai-template source | This reusable |
|---|---|---|
| `on:` | `push` on `main`/`feature/**` with `paths:` filter | `workflow_call` only (caller controls triggers) |
| `source-dir` (where `*.py` lives) | hardcoded `diagrams/` | input, default `diagrams` |
| `output-dir` (where PNGs go) | hardcoded `docs/diagrams/` | input, default `docs/diagrams` |
| `python-version` | hardcoded `3.12` | input, default `3.12` |
| `diagrams-version` | hardcoded `0.25.1` | input, default `0.25.1` |
| Commit message | hardcoded | input, default unchanged |
| `permissions: contents: write` | workflow-level | job-level (smaller blast radius) |
| `timeout-minutes` | none | `15` (consistency with other reusables) |
| Action versions | `@v4`, `@v5` | SHA-pinned with `# vX.Y.Z` comment |

## Why one of two candidates

`validate-ai-layer.yml` lists specific internal agent, skill, hook, and rule paths and explicitly states it is "synced to all downstream repos via sync-manifest.yml". Publishing it in this public repo would expose the structure of internal AI tooling. Keeping it in `ai-template` matches the same posture as `validate-template.yml`.

## Caller requirements (also documented in README)

- Caller must grant `permissions: contents: write` (the workflow declares the permission at the job level, but callers still need to allow it via the `permissions:` key on the calling job).
- Should be invoked on `push` events, not `pull_request` from forks (the push-back will fail with restricted token).
- Branch-protected branches requiring signed or reviewed commits will reject the bot's push — call this on a separate branch and open a PR if so.

## Test plan

- [ ] Call from a downstream repo with diagrams in the default location and verify PNGs render and commit
- [ ] Call from a downstream repo with custom `source-dir` / `output-dir` and verify inputs are honored
- [ ] Verify the no-op path: invoke when no `*.py` exists in `source-dir` — should log "No *.py files found" and exit 0 without committing
- [ ] Verify the unchanged-output path: invoke when rendered PNGs match what's already committed — should log "No changes to rendered output — skipping commit." and exit 0

## Follow-up (out of scope for this PR)

- Update `ai-template`'s own `render-diagrams.yml` to call this reusable instead. That's a change in a separate (private) repo and is part of #19's overall acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)