### PR TITLE
chore(deps): tighten Dependabot config — ignore majors, fix commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       actions:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
     commit-message:
       prefix: "chore(deps)"
-      include: scope


### PR DESCRIPTION
## Summary

Two issues showed up on Dependabot's first run (PR #21, opened ~immediately after #20 merged):

1. **Major version jumps proposed automatically.** Dependabot proposed bumping `actions/checkout` from 4.3.1 → 6.0.2 (skipping a full major), `actions/setup-node` to v6, and `github/codeql-action` similarly. #20 deliberately pinned to **v4.x / v3.x SHAs** to keep that work scope-pure ("pinning, not upgrading"). Auto-bumping majors silently undoes that decision and makes review harder (multi-major jumps can hide breaking changes between releases).
2. **Duplicate scope in commit prefix:** `chore(deps)(deps): Bump the actions group...`. The combination of `prefix: "chore(deps)"` + `include: scope` produces `(deps)(deps)`.

## Changes

```diff
     ignore:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
     commit-message:
-      prefix: "chore(deps)"
-      include: scope
+      prefix: "chore(deps)"
```

Net behavior:

- Dependabot proposes only **minor + patch** bumps automatically.
- Major upgrades stay **manual** — reviewer reads changelogs, decides intent, opens a PR.
- Commit messages render cleanly as `chore(deps): Bump the actions group with N updates`.

## What to do with PR #21

#21 is the major-bump PR Dependabot already opened. Once this lands, **close #21 without merging** — Dependabot will reopen with the correct (non-major) bumps on the next scan. Or, if there happen to be no minor/patch updates available beyond v4.x / v3.x latest (which we already pinned), Dependabot simply won't open anything.

## Test plan

- [ ] Once merged, manually trigger Dependabot (Insights → Dependency graph → Dependabot → "Check for updates") and confirm no new PR is opened proposing v6 majors
- [ ] When the next legitimate minor/patch bump happens, confirm the PR title is `chore(deps): Bump the actions group with N updates` (single `(deps)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)